### PR TITLE
Updates cssnano package to version ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "autoprefixer": "^10.2.4",
     "babel-loader": "^8.2.2",
     "css-loader": "^5.0.1",
-    "cssnano": "^4.1.7",
+    "cssnano": "^5.0.0",
     "dw-utils": "^1.3.137",
     "eslint": "^7.19.0",
     "eslint-config-idiomatic": "^4.0.0",


### PR DESCRIPTION
This PR updates the cssnano package version to ^5.0.0 to resolve a [reported high-severity issue with nth-check.](https://github.com/advisories/GHSA-rp65-9cf3-cjxr)

This is the current dependency path: @borngroup/born-build > cssnano > cssnano-preset-default > postcss-svgo > svgo > css-select > nth-check.

Updating cssnano to ^5.0.0 makes the following downstream updates: 

1. cssnano-preset-default from 4.0.8 to 5.2.14
2. postcss-svgo from 4.0.3 to 5.1.0
3. svgo from 1.3.2 to 2.8.0
4. css-select from 2.1.0 to 4.3.0
5. nth-check from 1.0.2 to 2.1.1

This update has been checked with a current SFCC project and the build completes without any issues.